### PR TITLE
add Pseudo platform driver

### DIFF
--- a/custom_drivers/Pseudo_Platform_Device/Makefile
+++ b/custom_drivers/Pseudo_Platform_Device/Makefile
@@ -1,0 +1,17 @@
+obj-m := pseudo_device_setup.o pseudo_platform_driver.o
+ARCH?=arm
+CROSS_COMPILE=arm-linux-gnueabihf-
+LINUX_SRC=../../linux
+HOST_LINUX_SRC=/lib/modules/$(shell uname -r)/build/
+all:
+	@make ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(LINUX_SRC) M=$(PWD) modules
+ 
+clean:
+	@make ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(LINUX_SRC) M=$(PWD) clean
+
+#compile the moudle in host architecture
+host:
+	@make -C $(HOST_LINUX_SRC) M=$(PWD) modules
+
+help:
+	@make ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) -C $(LINUX_SRC) M=$(PWD) help

--- a/custom_drivers/Pseudo_Platform_Device/platform.h
+++ b/custom_drivers/Pseudo_Platform_Device/platform.h
@@ -3,6 +3,7 @@
 
 /*number of platform devices*/
 #define PLF_DEV_COUNT           2
+#define MAX_NUMBER_OF_DEVICES   5
 
 /*device permission*/
 #define RONLY_PERMISSION        0b01

--- a/custom_drivers/Pseudo_Platform_Device/platform.h
+++ b/custom_drivers/Pseudo_Platform_Device/platform.h
@@ -1,0 +1,25 @@
+#ifndef  __PLF_CFG_
+#define  __PLF_CFG_
+
+/*number of platform devices*/
+#define PLF_DEV_COUNT           2
+
+/*device permission*/
+#define RONLY_PERMISSION        0b01
+#define WONLY_PERMISSION        0b10
+#define RW_PERMISSION           0b11
+
+#define DEV0_MEM_SIZE           1024
+#define DEV1_MEM_SIZE           512
+
+/*device platform data*/
+struct pseudo_platform_data{
+    size_t size;
+    const char* serial_number;
+    /*first bit for read permission and second bit for write permission*/
+    /* example: 0b11 means RW permission                               */
+    int permission;
+};
+
+
+#endif

--- a/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
+++ b/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
@@ -1,7 +1,16 @@
+/**************************************************************/
+/*psuedo platform device driver                               */
+/*interface with 2 pseudo memory devices using platform driver*/
+/**************************************************************/
+
+/********file includes********/
+
 #include <linux/module.h>
 #include <linux/platform_device.h>
 #include "platform.h"
  
+
+/********data types definition********/
 
 struct pseudo_platform_data pseudo_plf_data[PLF_DEV_COUNT] = 
 {
@@ -54,6 +63,7 @@ static int __init pseudo_init(void)
 {
     platform_device_register(&pseudo_plf_dev0);
     platform_device_register(&pseudo_plf_dev1);
+    pr_info("%s:module loaded successfully\n",__func__);
     return 0;
 }
 
@@ -61,6 +71,7 @@ static void __exit pseudo_deinit(void)
 {
     platform_device_unregister(&pseudo_plf_dev0);
     platform_device_unregister(&pseudo_plf_dev1);
+    pr_info("%s:module unloaded\n",__func__);
 }
 
 void pseudo_dev_release(struct device*)

--- a/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
+++ b/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
@@ -9,6 +9,11 @@
 #include <linux/platform_device.h>
 #include "platform.h"
  
+/********functions decleartions*******/
+
+/*device release function*/
+void pseudo_dev_release(struct device*);
+
 
 /********data types definition********/
 
@@ -50,12 +55,6 @@ struct platform_device pseudo_plf_dev1 =
     }
 
 };
-/********functions decleartions*******/
-
-/*device release function*/
-void pseudo_dev_release(struct device*);
-
-
 
 /********functions implementation*******/
 

--- a/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
+++ b/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
@@ -25,7 +25,8 @@ struct platform_device pseudo_plf_dev0 =
     .id   = 0,
     .dev = 
     {
-        .platform_data = &pseudo_plf_data[0]
+        .platform_data = &pseudo_plf_data[0],
+        .release       = pseudo_dev_release
     }
 
 };
@@ -35,10 +36,19 @@ struct platform_device pseudo_plf_dev1 =
     .id   = 1,
     .dev = 
     {
-        .platform_data = &pseudo_plf_data[1]
+        .platform_data = &pseudo_plf_data[1],
+        .release       = pseudo_dev_release
     }
 
 };
+/********functions decleartions*******/
+
+/*device release function*/
+void pseudo_dev_release(struct device*);
+
+
+
+/********functions implementation*******/
 
 static int __init pseudo_init(void)
 {
@@ -51,6 +61,11 @@ static void __exit pseudo_deinit(void)
 {
     platform_device_unregister(&pseudo_plf_dev0);
     platform_device_unregister(&pseudo_plf_dev1);
+}
+
+void pseudo_dev_release(struct device*)
+{
+    pr_info("%s:platform device released\n",__func__);
 }
 
 /*module registration*/

--- a/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
+++ b/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
@@ -1,0 +1,64 @@
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include "platform.h"
+ 
+
+struct pseudo_platform_data pseudo_plf_data[PLF_DEV_COUNT] = 
+{
+    [0] = 
+    {
+        .size           = DEV0_MEM_SIZE,
+        .serial_number  = "PLFDEV0000",
+        .permission     = RONLY_PERMISSION
+    },
+    [1] = 
+    {
+        .size           = DEV1_MEM_SIZE,
+        .serial_number  = "PLFDEV0001",
+        .permission     = RW_PERMISSION
+    }
+};
+
+struct platform_device pseudo_plf_dev0 = 
+{
+    .name = "pseudo-char-dev",
+    .id   = 0,
+    .dev = 
+    {
+        .platform_data = &pseudo_plf_data[0]
+    }
+
+};
+struct platform_device pseudo_plf_dev1 = 
+{
+    .name = "pseudo-char-dev",
+    .id   = 1,
+    .dev = 
+    {
+        .platform_data = &pseudo_plf_data[1]
+    }
+
+};
+
+static int __init pseudo_init(void)
+{
+    platform_device_register(&pseudo_plf_dev0);
+    platform_device_register(&pseudo_plf_dev1);
+    return 0;
+}
+
+static void __exit pseudo_deinit(void)
+{
+    platform_device_unregister(&pseudo_plf_dev0);
+    platform_device_unregister(&pseudo_plf_dev1);
+}
+
+/*module registration*/
+module_init(pseudo_init);
+module_exit(pseudo_deinit);
+
+/*module description*/
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Mohammed Thabet");
+MODULE_DESCRIPTION("pseudo platform char device driver");
+MODULE_INFO(HW, "x86 machine");

--- a/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
+++ b/custom_drivers/Pseudo_Platform_Device/pseudo_device_setup.c
@@ -58,29 +58,30 @@ struct platform_device pseudo_plf_dev1 =
 
 /********functions implementation*******/
 
-static int __init pseudo_init(void)
+static int __init pseudo_plf_dev_init(void)
 {
     platform_device_register(&pseudo_plf_dev0);
     platform_device_register(&pseudo_plf_dev1);
-    pr_info("%s:module loaded successfully\n",__func__);
+    pr_info("%s:plf setup module loaded successfully\n",__func__);
     return 0;
 }
 
-static void __exit pseudo_deinit(void)
+static void __exit pseudo_plf_dev_deinit(void)
 {
+    /*if you have too many devices, you can use  platform_add_devices(struct platform_device **devs, int num)*/
     platform_device_unregister(&pseudo_plf_dev0);
     platform_device_unregister(&pseudo_plf_dev1);
-    pr_info("%s:module unloaded\n",__func__);
+    pr_info("%s:plf setup module unloaded\n",__func__);
 }
 
-void pseudo_dev_release(struct device*)
+void pseudo_dev_release(struct device* dev)
 {
     pr_info("%s:platform device released\n",__func__);
 }
 
 /*module registration*/
-module_init(pseudo_init);
-module_exit(pseudo_deinit);
+module_init(pseudo_plf_dev_init);
+module_exit(pseudo_plf_dev_deinit);
 
 /*module description*/
 MODULE_LICENSE("GPL");

--- a/custom_drivers/Pseudo_Platform_Device/pseudo_platform_driver.c
+++ b/custom_drivers/Pseudo_Platform_Device/pseudo_platform_driver.c
@@ -1,0 +1,147 @@
+/*************************************************************/
+/*N psuedo devices driver                                    */
+/*interface with 4 pseudo memory devices using one driver    */
+/*************************************************************/
+
+/*header section*/
+#include <linux/module.h>
+#include <linux/fs.h>
+#include <linux/cdev.h>
+#include <linux/device.h>
+#include <linux/kdev_t.h>
+#include <linux/uaccess.h>
+#include <linux/platform_device.h>
+#include "platform.h"
+
+/*file operations*/
+loff_t pseudo_llseek (struct file *file_ptr, loff_t offset, int whence);
+ssize_t pseudo_read (struct file *file_ptr, char __user *buffer, size_t count, loff_t *f_pos);
+ssize_t pseudo_write (struct file *file_ptr, const char __user *buffer, size_t count, loff_t *f_pos);\
+int pseudo_open (struct inode *inode_ptr, struct file *file_ptr);
+int pseudo_release (struct inode *inode_ptr, struct file *file_ptr);
+
+
+int pseudo_plf_probe(struct platform_device *plf_dev);
+int pseudo_plf_remove(struct platform_device *plf_dev);
+
+int check_file_permission(int device_permission, fmode_t mode);
+
+
+/*device private data*/
+struct dev_priv_data
+{
+        char*  data_buffer;
+        struct pseudo_platform_data plf_data;
+        dev_t  dev_num;
+        struct cdev dev_cdev;
+        struct device *dev_ptr;
+};
+
+/*driver private data*/
+struct drv_priv_data
+{
+    int devices_count;
+    dev_t dev_num_base;
+    struct class *dev_class;
+    struct dev_priv_data *devs_data;
+};
+
+struct drv_priv_data drv_data;
+
+/*file_operations struct*/
+struct file_operations pseudo_fops = {
+    .open       = pseudo_open,
+    .release    = pseudo_release,
+    .read       = pseudo_read,
+    .write      = pseudo_write,
+    .llseek     = pseudo_llseek,
+    .owner      = THIS_MODULE
+};
+
+
+/*code section*/
+static int __init pseudo_plf_drv_init(void)
+{
+    
+    return 0;
+
+}
+
+static void __exit pseudo_plf_drv_deinit(void)
+{
+    
+}
+
+
+int pseudo_plf_probe(struct platform_device* plf_dev)
+{
+    
+
+    return 0;
+
+}
+
+int pseudo_plf_remove(struct platform_device* plf_dev)
+{
+    
+    return 0;
+}
+
+int pseudo_open (struct inode *inode_ptr, struct file *file_ptr)
+{
+    
+	return 0;
+}
+int pseudo_release (struct inode *inode_ptr, struct file *file_ptr)
+{
+	return 0;
+}
+
+ssize_t pseudo_read (struct file *file_ptr, char __user *buffer, size_t count, loff_t *f_pos)
+{
+    
+	return 0;
+}
+
+ssize_t pseudo_write (struct file *file_ptr, const char __user *buffer, size_t count, loff_t *f_pos)
+{
+	return 0;
+}
+
+loff_t pseudo_llseek (struct file *file_ptr, loff_t offset, int whence)
+{
+	return 0;
+}
+
+int check_file_permission(int device_permission, fmode_t request_mode)
+{
+    if(device_permission == RW_PERMISSION)
+        return 0;
+    
+    /*if the device is read only, check if open request mode is read only*/
+    if(device_permission == RONLY_PERMISSION)
+    {
+        if((request_mode & FMODE_READ) && !(request_mode & FMODE_WRITE))
+            return 0;
+    }
+
+    /*if the device is write only, check if open request mode is write only*/
+    if(device_permission == WONLY_PERMISSION)
+    {
+        if((request_mode & FMODE_WRITE) && !(request_mode & FMODE_READ))
+            return 0;
+    }
+
+    return -EPERM;
+}
+
+/*registration section*/
+module_init(pseudo_plf_drv_init);
+module_exit(pseudo_plf_drv_deinit);
+
+/*registration description*/
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Mohammed Thabet");
+MODULE_DESCRIPTION("pseudo platform char device driver");
+MODULE_INFO(HW, "x86 machine");


### PR DESCRIPTION
platform driver manages multiple pseudo-memory devices.
the driver uses name-matching to match the driver with the devices
device setup configured in platform_device_setup module